### PR TITLE
Honour `INPUT_PORT` in pre- and post-upload hooks.

### DIFF
--- a/with_key.sh
+++ b/with_key.sh
@@ -7,7 +7,7 @@ PRE_UPLOAD=${INPUT_PRE_UPLOAD}
 if [ ! -z "$PRE_UPLOAD" ]; then
     { 
         echo "👌 Executing pre-upload script..." &&
-        ssh ${INPUT_SSH_OPTIONS} ${INPUT_USER}@${INPUT_HOST} "$INPUT_PRE_UPLOAD && exit" &&
+        ssh ${INPUT_SSH_OPTIONS} -p "${INPUT_PORT}" ${INPUT_USER}@${INPUT_HOST} "$INPUT_PRE_UPLOAD && exit" &&
         echo "✅ Executed pre-upload script"
     } || { 
         echo "😢 Something went wrong during pre-upload script" && exit 1
@@ -26,7 +26,7 @@ POST_UPLOAD=${INPUT_POST_UPLOAD}
 if [ ! -z "$POST_UPLOAD" ]; then
     {
         echo "👌 Executing post-upload script..." &&
-        ssh ${INPUT_SSH_OPTIONS} ${INPUT_USER}@${INPUT_HOST} "$POST_UPLOAD && exit" &&
+        ssh ${INPUT_SSH_OPTIONS} -p "${INPUT_PORT}" ${INPUT_USER}@${INPUT_HOST} "$POST_UPLOAD && exit" &&
         echo "✅ Executed post-upload script"
     } || {
         echo "😢 Something went wrong during post-upload script" && exit 1

--- a/with_pass.sh
+++ b/with_pass.sh
@@ -2,7 +2,7 @@ PRE_UPLOAD=${INPUT_PRE_UPLOAD}
 if [ ! -z "$PRE_UPLOAD" ]; then
     {
         echo "👌 Executing pre-upload script..." &&
-        sshpass -p ${PASSWORD} ssh ${INPUT_SSH_OPTIONS} ${INPUT_USER}@${INPUT_HOST} "$INPUT_PRE_UPLOAD && exit" &&
+        sshpass -p ${PASSWORD} ssh ${INPUT_SSH_OPTIONS} -p "${INPUT_PORT}" ${INPUT_USER}@${INPUT_HOST} "$INPUT_PRE_UPLOAD && exit" &&
         echo "✅ Executed pre-upload script"
     } || { 
         echo "😢 Something went wrong during pre-upload script" && exit 1
@@ -21,7 +21,7 @@ POST_UPLOAD=${INPUT_POST_UPLOAD}
 if [ ! -z "$POST_UPLOAD" ]; then
     {
         echo "👌 Executing post-upload script..." &&
-        sshpass -p ${PASSWORD} ssh ${INPUT_SSH_OPTIONS} ${INPUT_USER}@${INPUT_HOST} "$POST_UPLOAD && exit" &&
+        sshpass -p ${PASSWORD} ssh ${INPUT_SSH_OPTIONS} -p "${INPUT_PORT}" ${INPUT_USER}@${INPUT_HOST} "$POST_UPLOAD && exit" &&
         echo "✅ Executed post-upload script"
     } || {
         echo "😢 Something went wrong during post-upload script" && exit 1


### PR DESCRIPTION
This adds `-p "${INPUT_PORT}"` to the `ssh` commandlines used for the pre- and post-commit scripts.

Resolves #15.